### PR TITLE
PlotSpecActivity_fixes

### DIFF
--- a/R/Stuff.R
+++ b/R/Stuff.R
@@ -737,6 +737,8 @@ plotSpecActivity <- function(simlist, subs=list(), var_nr=10, spec_list=NULL, re
   if(is(simlist, "Eval")) simlist <- list(simlist)
   if(length(subs)==0) {subs_tocheck <- names(getVarSubs(simlist[[1]]))
   }else subs_tocheck <- subs
+  if(length(spec_list)>0) #If spec list is provided, then the system takes the index numbers and replaces them with their real names like in line 742
+  {for (i in (spec_list)) {spec_list[which(spec_list==i)]<-names(simlist[[1]]@specs)[i]}}
   if(length(spec_list)==0) spec_list <- names(simlist[[1]]@specs)
   
   df <- data.frame(spec=as.character(), sub=as.character(), mflux=as.numeric(), time=as.integer())
@@ -761,15 +763,18 @@ plotSpecActivity <- function(simlist, subs=list(), var_nr=10, spec_list=NULL, re
     mflux_var <- sort(mflux_var, decreasing = TRUE)
     df <- df[which(df$sub %in% names(mflux_var)[1:var_nr]),]
   }
-  
+
   q1 <- ggplot2::ggplot(df, ggplot2::aes_string(x="time", y="mflux")) + ggplot2::geom_line(ggplot2::aes_string(col="sub"), size=1) + 
         ggplot2::facet_wrap(~spec, scales="free_y") + ggplot2::xlab("") + ggplot2::ylab("mmol/(h*g_dw)")
-  
+  # q1_5 is the same as q2 but contains "+ ggplot2::facet_wrap(~spec, scales="free_y")" to plot the variance for each spec.   
+  q1_5 <- ggplot2::ggplot(df, ggplot2::aes_string("sub", "mflux")) + ggplot2::geom_boxplot(ggplot2::aes_string(color="sub", fill="sub"), alpha=0.2) + 
+    ggplot2::theme(axis.text.x =ggplot2::element_blank()) + ggplot2::xlab("") + ggplot2::ylab("mmol/(h*g_dw)") + ggplot2::facet_wrap(~spec, scales="free_y")
+    
   q2 <- ggplot2::ggplot(df, ggplot2::aes_string("sub", "mflux")) + ggplot2::geom_boxplot(ggplot2::aes_string(color="sub", fill="sub"), alpha=0.2) + 
     ggplot2::theme(axis.text.x =ggplot2::element_blank()) + ggplot2::xlab("") + ggplot2::ylab("mmol/(h*g_dw)")
-  if(length(levels(df$spec)) > 1) q2 <- q2 + ggplot2::facet_wrap(~spec, scales="free_y")
+  #if(length(levels(df$spec)) > 1) q2 <- q2 + ggplot2::facet_wrap(~spec, scales="free_y") Not needed anymore because it is included in q1_5
   
-  if(ret_data) return(df) else return(list(q1, q2))
+  if(ret_data) return(df) else return(list(q1, q1_5, q2))
 }
 
 


### PR DESCRIPTION
Line 775 does not work properly when the user selects specs (e.g. spec_list = c(1,4)). If c is place where the retdata are saved, the length(levels(c$spec)) gives result zero, when spec_list  is comprised of numbers. As result the if condition returns false, and the rest of commands will not run. To overcome this problem, I introduced the lines 740-741, so that the systems takes the numbers of spec_list and returns their names as strings. Then the function works as previously.  The functionality of line 775 is transferred in the graph g1_5, as the latter is the same as q2 but contains "+ ggplot2::facet_wrap(~spec, scales="free_y")" to plot the variance for each spec. The q2 remains intact because (when 775 did not work) it used to plot the overall variance, as @euba proposed in the issue https://github.com/euba/BacArena/issues/60 . The information of g2 may be of interest to researchers in the future [@euba].

To check the differences, I propose to check these commands before and after:
plotSpecActivity(sihumi_test,spec_list = c(1))
a<-plotSpecActivity(sihumi_test,spec_list = c(1),ret_data = T)
plotSpecActivity(sihumi_test,spec_list = c(1,2))
b<-plotSpecActivity(sihumi_test,spec_list = c(1,2),ret_data = T)
plotSpecActivity(sihumi_test)
c<-plotSpecActivity(sihumi_test,ret_data = T)

Of course, this is a suggestion only, an independent and thorough review process is always needed. 