### PR TITLE
Adapted findfeeding3 and a new function HeatMapFeeding

### DIFF
--- a/R/Arena.R
+++ b/R/Arena.R
@@ -2998,26 +2998,26 @@ setMethod("plotSubDist2", "Eval", function(object, sub, times=NULL){
   return(q)
 })
 
-#' @title Function for plotting heatmaps of feeding between two selected cell models
+#' @title Function for plotting heatmap of feeding between two selected cell models
 #'
-#' @description The generic function \code{HeatMapFeeding} returns heatmaps between two selected cell models. If there is feeding, heatmaps show only 
-#' the producer. The compounds are originated from the most varying substances of the cell model "speciesA".
+#' @description The generic function \code{HeatMapFeeding} returns a heatmap between two selected cell models. If there is feeding, the heatmap show only 
+#' the producer. The compounds are originated from the most varying substances of the first cell model called "speciesA".
 #' @export
 #' @rdname HeatMapFeeding
-#' 
+#' @usage HeatMapFeeding(object, speciesA, speciesB, var_nr)
 #' @param object An object of class Eval.
 #' @param speciesA The sequence number of the first cell model in names(object@specs)
 #' @param speciesB The sequence number of the second cell model in names(object@specs)
 #' @param var_nr The number of the most varying speciesA's substances following plotSpecActivity structure
 #' @return Heatmap (ggplot2)
 #' 
-#' @example 
-#' # Do Not Run
-#' # sim : simulation object
-#' # speciesA = 1 # E. Coli (wild): sequence number in names(sim@specs) => 1
-#' # speciesB = 3 # E. Coli (mutant): sequence number in names(sim@specs) => 3
-#' # var_nr = 30 # (manually selected)
-#' # HeatMapFeeding(object = sim, speciesA = 1, speciesB = 3, var_nr = 30)
+#' @examples 
+#'  Do Not Run
+#'  sim : simulation object
+#'  speciesA = 1 # E. Coli (wild): sequence number in names(sim@specs) => 1
+#'  speciesB = 3 # E. Coli (mutant): sequence number in names(sim@specs) => 3
+#'  var_nr = 30 # (manually selected)
+#'  HeatMapFeeding(object = sim, speciesA = 1, speciesB = 3, var_nr = 30)
 #' 
 setGeneric("HeatMapFeeding", function(object, speciesA, speciesB, var_nr){standardGeneric("HeatMapFeeding")})
 #' @export
@@ -3026,7 +3026,7 @@ setMethod("HeatMapFeeding", "Eval", function(object, speciesA, speciesB, var_nr)
   A<-BacArena::plotSpecActivity(object,spec_list = speciesA, var_nr = var_nr, ret_data = T)
   z<-data.frame()
   chronos <- (seq_along(object@simlist)-1)
-  for (t in time) 
+  for (t in chronos) 
   { a<-data.frame()
   a <-BacArena::findFeeding3(object, time = t, mets = A$sub[1:var_nr], plot = F)
   if (nrow(a)!=0) 
@@ -3048,8 +3048,8 @@ setMethod("HeatMapFeeding", "Eval", function(object, speciesA, speciesB, var_nr)
   # GGPLOT METHOD based on https://stackoverflow.com/questions/8406394/how-to-produce-a-heatmap-with-ggplot2
   p2 <- p
   p.m <- reshape::melt(p2)
-  p3 <- ggplot2::ggplot(p.m, aes(sim_step,met)) +
-    ggplot2::geom_tile(aes(fill = value), colour = "white") +
+  p3 <- ggplot2::ggplot(p.m, ggplot2::aes(sim_step,met)) +
+    ggplot2::geom_tile(ggplot2::aes(fill = value), colour = "white") +
     ggplot2::scale_fill_gradient2(name = "Producer", low = "red", mid = "green", high = "blue", breaks=seq(-1,1,by=1),
                                   labels = c(names(sim@specs)[speciesB], "no feeding", names(sim@specs)[speciesA])) +
     ggplot2::xlab("Simulation Step") + ggplot2::ylab("Exchange Reactions") 

--- a/R/Arena.R
+++ b/R/Arena.R
@@ -2613,8 +2613,8 @@ setMethod("findFeeding3", "Eval", function(object, time, mets, plot=TRUE){
   }
   if(any(dim(inter)==0)) {
     warning(paste("sim_step",(time-1),":","No crossfeeding found. Try other metaboites or time points."))
-    g <- igraph::make_empty_graph()
-    return(list(inter,g))
+    #g <- igraph::make_empty_graph()
+    return(inter)
   }
   if (plot) {
   g <- igraph::graph.data.frame(inter[,1:2], directed=TRUE)


### PR DESCRIPTION
Dear All,

I am very happy to share with you my ideas about BacArena's code. Here I am presenting a new version of  findfeeding3 and a new function called HeatMapFeeding. The latter is based on the former.
Line by line:
1. 
2612: I included also the time in the inter object. The time is according to user's input, following the discussion https://github.com/euba/BacArena/issues/88 .
2.
2615-17:I added time stamp in the warning and I removed the empty graph (it is empty anyway!).
3.
2619-26: Although there was a `plot `argument in line 2597, this argument was "dead", so I "activated". If someone does not want to plot the interactions, probably she/he does not want the g object returned. I changed the code accordingly.
4.
3000-25: I was literally imitating your code, so that I can create the new function. In my built, the documentation is working well, except for the usage part where it shows:
```
# S4 method for signature 'Eval'
HeatMapFeeding(object, speciesA, speciesB, var_nr)

```
I do not know why it is shown. Please check it thoroughly and also check if my description is concise and coherent.
5.
3025-end: The main function is there! First it extracts the selected number of most varying molecules of the first cell model, then it searches for possible interactions by using the new findfeeding3 function. Each result is saved in the z data frame. Then it looks for the producers and this info is combined with z data frame. Some transformations follow and at the end it plots the heatmap.

These are my ideas. Please check them line by line. By the way, who has to rebuild the package in case of acceptance?

I look forward to any idea or criticism.
Regards,
@maringos

P.S. Acknowledgement to numerous websites that answered every each question of mine concerning the Implementation of my ideas.
